### PR TITLE
Add block deletion support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
 	</ciManagement>
 
 	<properties>
+		<n5.version>2.2.0</n5.version>
+
 		<package-name>org.janelia.saalfeldlab</package-name>
 
 		<license.licenseName>bsd_2</license.licenseName>
@@ -102,7 +104,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.3</version>
+			<version>${n5.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -118,7 +120,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.3</version>
+			<version>${n5.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
@@ -483,6 +483,35 @@ public class N5ZarrWriter extends N5ZarrReader implements N5Writer {
 	}
 
 	@Override
+	public boolean deleteBlock(final String pathName, final long[] gridPosition) throws IOException {
+
+		final DatasetAttributes datasetAttributes = getDatasetAttributes(pathName);
+
+		final ZarrDatasetAttributes zarrDatasetAttributes;
+		if (datasetAttributes instanceof ZarrDatasetAttributes)
+			zarrDatasetAttributes = (ZarrDatasetAttributes)datasetAttributes;
+		else
+			zarrDatasetAttributes = getZArraryAttributes(pathName).getDatasetAttributes();
+
+		final Path path = Paths.get(
+				basePath,
+				removeLeadingSlash(pathName),
+				getZarrDataBlockPath(
+						gridPosition,
+						dimensionSeparator,
+						zarrDatasetAttributes.isRowMajor()).toString());
+
+		if (!Files.exists(path))
+			return true;
+
+		try (final LockedFileChannel lockedChannel = LockedFileChannel.openForWriting(path)) {
+			Files.delete(path);
+		}
+
+		return !Files.exists(path);
+	}
+
+	@Override
 	public boolean remove() throws IOException {
 
 		return remove("/");

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -48,6 +48,7 @@ import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.n5.blosc.BloscCompression;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import net.imglib2.RandomAccess;
@@ -199,9 +200,8 @@ public class N5ZarrTest extends AbstractN5Test {
 
 	@Override
 	@Test
+	@Ignore("Zarr does not currently support mode 1 data blocks.")
 	public void testMode1WriteReadByteBlock() {
-
-		// Not supported by Zarr
 	}
 
 	private boolean runPythonTest() throws IOException, InterruptedException {


### PR DESCRIPTION
This PR adds support for block deletion introduced in N5 2.2.0.