### PR TITLE
Fix padcrop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
 
-		<scijava.jvm.build.version>[1.8.0-101,11]</scijava.jvm.build.version>
+		<scijava.jvm.build.version>[1.8.0-101,11.0.9999]</scijava.jvm.build.version>
 	</properties>
 
 	<developers>

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
@@ -395,13 +395,13 @@ public class N5ZarrWriter extends N5ZarrReader implements N5Writer {
 					j = 0;
 			}
 			final ArrayImg<ByteType, ByteArray> srcImg = ArrayImgs.bytes(src, srcIntervalDimensions);
-			final ArrayImg<ByteType, ByteArray> dstImg = ArrayImgs.bytes(dst, srcIntervalDimensions);
+			final ArrayImg<ByteType, ByteArray> dstImg = ArrayImgs.bytes(dst, dstIntervalDimensions);
 
 			final FinalInterval intersection = Intervals.intersect(srcImg, dstImg);
 			final Cursor<ByteType> srcCursor = Views.interval(srcImg, intersection).cursor();
 			final Cursor<ByteType> dstCursor = Views.interval(dstImg, intersection).cursor();
 			while (srcCursor.hasNext())
-				dstCursor.next().set(dstCursor.next());
+				dstCursor.next().set(srcCursor.next());
 
 			return dst;
 		} else {

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -121,6 +121,20 @@ public class N5ZarrTest extends AbstractN5Test {
 		}
 	}
 
+	@Test
+	public void testPadCrop() throws Exception {
+
+		byte[] src = new byte[] { 1, 1, 1, 1 };  // 2x2
+		int[] srcBlockSize = new int[] { 2, 2 };
+		int[] dstBlockSize = new int[] { 3, 3 };
+		int nBytes = 1;
+		int nBits = 0;
+		byte[] fillValue = new byte[] { 0 };
+
+		byte[] dst = N5ZarrWriter.padCrop(src, srcBlockSize, dstBlockSize, nBytes, nBits, fillValue);
+		Assert.assertArrayEquals(new byte[] { 1, 1, 0, 1, 1, 0, 0, 0, 0 }, dst);
+	}
+
 	@Override
 	@Test
 	public void testVersion() throws NumberFormatException, IOException {


### PR DESCRIPTION
Lots of `ArrayIndexOutOfBounds` exceptions being thrown when writing Zarr files with dimensions that do not divide evenly by tile size. Not sure if the pad crop was previously broken for all use cases but definitely for this one. This PR adds a fix and a simple unit test.

/cc @joshmoore, @melissalinkert