### PR TITLE
Set compressor to null in .zarray if RawCompressor is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
 			<version>${n5-imglib2.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+			<version>1.1.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
@@ -72,6 +72,7 @@ public class N5ZarrReader extends N5FSReader {
 
 		gsonBuilder.registerTypeAdapter(DType.class, new DType.JsonAdapter());
 		gsonBuilder.registerTypeAdapter(ZarrCompressor.class, ZarrCompressor.jsonAdapter);
+		gsonBuilder.serializeNulls();
 
 		return gsonBuilder;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
+import org.janelia.saalfeldlab.n5.RawCompression;
+
 
 /**
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
@@ -144,7 +146,7 @@ public class ZArrayAttributes {
 		map.put(shapeKey, shape);
 		map.put(chunksKey, chunks);
 		map.put(dTypeKey, dtype.toString());
-		map.put(compressorKey, compressor);
+		map.put(compressorKey, compressor instanceof RawCompression ? null : compressor);
 		map.put(fillValueKey, fill_value);
 		map.put(orderKey, order);
 		map.put(filtersKey, filters);

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
@@ -47,6 +49,9 @@ import org.janelia.saalfeldlab.n5.N5Reader.Version;
 import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.n5.blosc.BloscCompression;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -389,6 +394,21 @@ public class N5ZarrTest extends AbstractN5Test {
 		/* remove the container */
 		n5Zarr.remove();
 	}
+
+	@Test
+	public void testRawCompressorNullInZarray() throws IOException, FileNotFoundException, ParseException {
+		N5ZarrWriter n5 = new N5ZarrWriter(testZarrDirPath);
+		n5.createDataset(testZarrDatasetName, new long[]{1, 2, 3}, new int[]{1, 2, 3}, DataType.UINT16, new RawCompression());
+		JSONParser jsonParser = new JSONParser();
+		try (FileReader freader = new FileReader(testZarrDirPath + testZarrDatasetName + "/.zarray")) {
+			JSONObject zarray = (JSONObject) jsonParser.parse(freader);
+			JSONObject compressor = (JSONObject) zarray.get("compressor");
+			assertTrue(compressor == null);
+		} finally {
+			n5.remove();
+		}
+	}
+
 
 //	/**
 //	 * @throws IOException


### PR DESCRIPTION
If a `.zarr` file is written with `N5ZarrWriter` and `RawCompressor` is used, the resulting `.zarray` file will have `"compressor":{"type":"raw"}`. When Python Zarr attempts to open this dataset, it crashes with the error `ValueError: codec not available: None`. According to the Zarr specification, if no compression is being used, `compressor` should be set to `null` (https://zarr.readthedocs.io/en/stable/spec/v2.html#metadata).
This PR modifies the way the `.zarray` file is written so that when `RawCompressor` is used, `compressor` is set to `null` in the `.zarray` file.
The following piece of Java code will create a very simple Zarr dataset which has the compressor set to `{"type":"raw"}`:
```
public void testWriteRawCompression() throws IOException {
        String zarrPath = System.getProperty("user.home") + "/tmp/raw-zarr-test.zarr";
        String datasetName = "/test/data";
        final short[] dataBlockData = new short[]{1, 2, 3, 4, 5, 6};
        N5Writer n5 = new N5ZarrWriter(zarrPath);
        n5.createDataset(datasetName, new long[]{1, 2, 3}, new int[]{1, 2, 3}, DataType.UINT16, new RawCompression());
        final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
        final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{1, 2, 3}, new long[]{0, 0, 0}, dataBlockData);
        n5.writeBlock(datasetName, attributes, dataBlock);
    }
```

The error can be induced by opening Python and running:
```
>>> import zarr
>>> z = zarr.open('/home/user/tmp/raw-zarr-test.zarr', mode='r')
>>> z['test']['data'][:]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kevin/code/gs-zarr-n5/python-utils/gs-zarr-venv/lib/python3.6/site-packages/zarr/hierarchy.py", line 340, in __getitem__
    synchronizer=self._synchronizer, cache_attrs=self.attrs.cache)
  File "/home/kevin/code/gs-zarr-n5/python-utils/gs-zarr-venv/lib/python3.6/site-packages/zarr/core.py", line 124, in __init__
    self._load_metadata()
  File "/home/kevin/code/gs-zarr-n5/python-utils/gs-zarr-venv/lib/python3.6/site-packages/zarr/core.py", line 141, in _load_metadata
    self._load_metadata_nosync()
  File "/home/kevin/code/gs-zarr-n5/python-utils/gs-zarr-venv/lib/python3.6/site-packages/zarr/core.py", line 169, in _load_metadata_nosync
    self._compressor = get_codec(config)
  File "/home/kevin/code/gs-zarr-n5/python-utils/gs-zarr-venv/lib/python3.6/site-packages/numcodecs/registry.py", line 36, in get_codec
    raise ValueError('codec not available: %r' % codec_id)
ValueError: codec not available: None
```

Running the same Java code with the PR yields:
```
>>> import zarr
>>> z = zarr.open('/home/user/tmp/raw-zarr-test.zarr', mode='r')
>>> z['test']['data'][:]
array([[[1],
        [2]],

       [[3],
        [4]],

       [[5],
        [6]]], dtype=uint16)
```