### PR TITLE
Fix case dataset name is null or slash

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
@@ -256,8 +256,9 @@ public class N5ZarrWriter extends N5ZarrReader implements N5Writer {
 			final String pathName,
 			final DatasetAttributes datasetAttributes) throws IOException {
 
-		/* create parent groups */
-		final String parentGroup = pathName.substring(0, removeTrailingSlash(pathName).lastIndexOf('/'));
+        /* create parent groups */
+		int tailingIndex = removeTrailingSlash(pathName).lastIndexOf('/');
+		final String parentGroup = (tailingIndex >= 0) ? pathName.substring(0, removeTrailingSlash(pathName).lastIndexOf('/')) : pathName;
 		if (!parentGroup.equals(""))
 			createGroup(parentGroup);
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -145,6 +145,37 @@ public class N5ZarrTest extends AbstractN5Test {
 	}
 
 	@Test
+	public void testCreateNestedDatasetNameNull() {
+
+		final String datasetName = "/test/nested/data";
+		try {
+			N5ZarrWriter n5Nested = new N5ZarrWriter(testDirPath, "/", true );
+			n5Nested.createDataset("", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
+			assertEquals( "/", n5Nested.getZArraryAttributes(datasetName).getDimensionSeparator());
+
+			n5Nested.remove(datasetName);
+			n5Nested.close();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testCreateNestedDatasetNameSlash() {
+
+		final String datasetName = "/test/nested/data";
+		try {
+			N5ZarrWriter n5Nested = new N5ZarrWriter(testDirPath, "/", true );
+			n5Nested.createDataset("/", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
+			assertEquals( "/", n5Nested.getZArraryAttributes(datasetName).getDimensionSeparator());
+
+			n5Nested.remove(datasetName);
+			n5Nested.close();
+		} catch (IOException e) {
+			fail(e.getMessage());
+		}
+	}
+	@Test
 	public void testPadCrop() throws Exception {
 
 		final byte[] src = new byte[] { 1, 1, 1, 1 };  // 2x2

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -145,32 +145,24 @@ public class N5ZarrTest extends AbstractN5Test {
 	}
 
 	@Test
-	public void testCreateNestedDatasetNameNull() {
-
-		final String datasetName = "/test/nested/data";
+	public void testCreateDatasetNameNull() {
 		try {
-			N5ZarrWriter n5Nested = new N5ZarrWriter(testDirPath, "/", true );
-			n5Nested.createDataset("", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
-			assertEquals( "/", n5Nested.getZArraryAttributes(datasetName).getDimensionSeparator());
-
-			n5Nested.remove(datasetName);
-			n5Nested.close();
+			N5ZarrWriter n5 = new N5ZarrWriter(testDirPath );
+			n5.createDataset("", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
+			n5.remove();
+			n5.close();
 		} catch (IOException e) {
 			fail(e.getMessage());
 		}
 	}
 
 	@Test
-	public void testCreateNestedDatasetNameSlash() {
-
-		final String datasetName = "/test/nested/data";
+	public void testCreateDatasetNameSlash() {
 		try {
-			N5ZarrWriter n5Nested = new N5ZarrWriter(testDirPath, "/", true );
-			n5Nested.createDataset("/", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
-			assertEquals( "/", n5Nested.getZArraryAttributes(datasetName).getDimensionSeparator());
-
-			n5Nested.remove(datasetName);
-			n5Nested.close();
+			N5ZarrWriter n5 = new N5ZarrWriter(testDirPath );
+			n5.createDataset("", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
+			n5.remove();
+			n5.close();
 		} catch (IOException e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -145,7 +145,7 @@ public class N5ZarrTest extends AbstractN5Test {
 	}
 
 	@Test
-	public void testCreateDatasetNameNull() {
+	public void testCreateDatasetNameEmpty() {
 		try {
 			N5ZarrWriter n5 = new N5ZarrWriter(testDirPath );
 			n5.createDataset("", dimensions, blockSize, DataType.UINT64, getCompressions()[0]);


### PR DESCRIPTION
Within Zarr, we can have a file without a dataset name. This case was working in reading and getAttributes
but it was causing a bug in create and save.  I fixed the bug and added a test cases