### PR TITLE
Return null in getZarrayAttributes if array attributes are not available

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
@@ -249,7 +249,10 @@ public class N5ZarrReader extends N5FSReader {
 										StandardCharsets.UTF_8.name()),
 								gson));
 			}
-		} else System.out.println(path.toString() + " does not exist.");
+		} else {
+			System.out.println(path.toString() + " does not exist.");
+			return null;
+		}
 
 		JsonElement sepElem = attributes.get("dimension_separator");
 		return new ZArrayAttributes(

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
@@ -234,7 +234,7 @@ public class N5ZarrReader extends N5FSReader {
 		return Files.exists(path) && Files.isRegularFile(path);
 	}
 
-	public ZArrayAttributes getZArraryAttributes(final String pathName) throws IOException {
+	public ZArrayAttributes getZArrayAttributes(final String pathName) throws IOException {
 
 		final Path path = Paths.get(basePath, removeLeadingSlash(pathName), zarrayFile);
 		final HashMap<String, JsonElement> attributes = new HashMap<>();
@@ -267,7 +267,7 @@ public class N5ZarrReader extends N5FSReader {
 	@Override
 	public DatasetAttributes getDatasetAttributes(final String pathName) throws IOException {
 
-		final ZArrayAttributes zArrayAttributes = getZArraryAttributes(pathName);
+		final ZArrayAttributes zArrayAttributes = getZArrayAttributes(pathName);
 		return zArrayAttributes == null ? null : zArrayAttributes.getDatasetAttributes();
 	}
 
@@ -319,7 +319,7 @@ public class N5ZarrReader extends N5FSReader {
 
 		if (mapN5DatasetAttributes && datasetExists(pathName)) {
 
-			final DatasetAttributes datasetAttributes = getZArraryAttributes(pathName).getDatasetAttributes();
+			final DatasetAttributes datasetAttributes = getZArrayAttributes(pathName).getDatasetAttributes();
 			attributes.put("dimensions", gson.toJsonTree(datasetAttributes.getDimensions()));
 			attributes.put("blockSize", gson.toJsonTree(datasetAttributes.getBlockSize()));
 			attributes.put("dataType", gson.toJsonTree(datasetAttributes.getDataType()));
@@ -450,7 +450,7 @@ public class N5ZarrReader extends N5FSReader {
 		if (datasetAttributes instanceof ZarrDatasetAttributes)
 			zarrDatasetAttributes = (ZarrDatasetAttributes)datasetAttributes;
 		else
-			zarrDatasetAttributes = getZArraryAttributes(pathName).getDatasetAttributes();
+			zarrDatasetAttributes = getZArrayAttributes(pathName).getDatasetAttributes();
 
 		final String dimSep;
 		final String attrDimensionSeparator = zarrDatasetAttributes.getDimensionSeparator();

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
@@ -290,7 +290,7 @@ public class N5ZarrWriter extends N5ZarrReader implements N5Writer {
 			if (mapN5DatasetAttributes && datasetExists(pathName)) {
 
 				attributes = new HashMap<>(attributes);
-				ZArrayAttributes zArrayAttributes = getZArraryAttributes(pathName);
+				ZArrayAttributes zArrayAttributes = getZArrayAttributes(pathName);
 				long[] shape;
 				int[] chunks;
 				final DType dtype;
@@ -467,7 +467,7 @@ public class N5ZarrWriter extends N5ZarrReader implements N5Writer {
 		if (datasetAttributes instanceof ZarrDatasetAttributes)
 			zarrDatasetAttributes = (ZarrDatasetAttributes)datasetAttributes;
 		else
-			zarrDatasetAttributes = getZArraryAttributes(pathName).getDatasetAttributes();
+			zarrDatasetAttributes = getZArrayAttributes(pathName).getDatasetAttributes();
 
 		final Path path = Paths.get(
 				basePath,
@@ -496,7 +496,7 @@ public class N5ZarrWriter extends N5ZarrReader implements N5Writer {
 		if (datasetAttributes instanceof ZarrDatasetAttributes)
 			zarrDatasetAttributes = (ZarrDatasetAttributes)datasetAttributes;
 		else
-			zarrDatasetAttributes = getZArraryAttributes(pathName).getDatasetAttributes();
+			zarrDatasetAttributes = getZArrayAttributes(pathName).getDatasetAttributes();
 
 		final Path path = Paths.get(
 				basePath,

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -156,6 +156,18 @@ public class N5ZarrTest extends AbstractN5Test {
 	}
 
 	@Test
+	public void testGetDatasetAttributesNull() throws IOException {
+		final N5ZarrWriter n5 = new N5ZarrWriter(testDirPath);
+		try {
+			final DatasetAttributes attributes = n5.getDatasetAttributes("");
+			assertNull(attributes);
+		} finally {
+			n5.remove();
+			n5.close();
+		}
+	}
+
+	@Test
 	public void testPadCrop() throws Exception {
 		final byte[] src = new byte[] { 1, 1, 1, 1 };  // 2x2
 		final int[] srcBlockSize = new int[] { 2, 2 };

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -133,7 +133,7 @@ public class N5ZarrTest extends AbstractN5Test {
 
 		N5ZarrWriter n5Nested = new N5ZarrWriter(testDirPath, "/", true );
 		n5Nested.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
-		assertEquals( "/", n5Nested.getZArraryAttributes(datasetName).getDimensionSeparator());
+		assertEquals( "/", n5Nested.getZArrayAttributes(datasetName).getDimensionSeparator());
 
 		n5Nested.remove(datasetName);
 		n5Nested.close();
@@ -400,7 +400,7 @@ public class N5ZarrTest extends AbstractN5Test {
 		final RandomAccessibleInterval<UnsignedIntType> a3x2_c_bu4_f1_after = N5Utils.open(n5Zarr, datasetName);
 		assertIsSequence(Views.interval(a3x2_c_bu4_f1_after,  a3x2_c_bu4_f1), refUnsignedInt);
 		final RandomAccess<UnsignedIntType> ra = a3x2_c_bu4_f1_after.randomAccess();
-		final int fill_value = Integer.parseInt(n5Zarr.getZArraryAttributes(datasetName).getFillValue());
+		final int fill_value = Integer.parseInt(n5Zarr.getZArrayAttributes(datasetName).getFillValue());
 		ra.setPosition(shape[0] - 5, 0);
 		assertEquals(fill_value, ra.get().getInteger());
 		ra.setPosition(shape[1] - 5, 1);
@@ -451,7 +451,7 @@ public class N5ZarrTest extends AbstractN5Test {
 		assertArrayEquals(datasetAttributesC.getDimensions(), new long[]{3, 2});
 		assertArrayEquals(datasetAttributesC.getBlockSize(), new int[]{3, 2});
 		assertEquals(datasetAttributesC.getDataType(), DataType.UINT8);
-		assertEquals( n5Zarr.getZArraryAttributes(testZarrDatasetName + "/3x2_c_|u1").getDimensionSeparator(), "/" );
+		assertEquals( n5Zarr.getZArrayAttributes(testZarrDatasetName + "/3x2_c_|u1").getDimensionSeparator(), "/" );
 
 		final UnsignedByteType refUnsignedByte = new UnsignedByteType();
 		assertIsSequence(N5Utils.open(n5Zarr, testZarrDatasetName + "/3x2_c_|u1"), refUnsignedByte);


### PR DESCRIPTION
Currently, calling `N5ZarrReader.getDatasetAttributes(notADataset)` is called for a path that is not a dataset throws a `NullPointerException`:
```
java.lang.NullPointerException: Cannot invoke "com.google.gson.JsonElement.getAsInt()" because the return value of "java.util.HashMap.get(Object)" is null

        at org.janelia.saalfeldlab.n5.zarr.N5ZarrReader.getZArrayAttributes(N5ZarrReader.java:256)
        at org.janelia.saalfeldlab.n5.zarr.N5ZarrReader.getDatasetAttributes(N5ZarrReader.java:270)
        at org.janelia.saalfeldlab.n5.zarr.N5ZarrTest.testGetDatasetAttributesNull(N5ZarrTest.java:162)
```

This PR addresses this:
 1. Return `null` if `not/a/dataset/path/.zarray` does not exist (Previously, it would only log `System.out.println(path.toString() + " does not exist.");`)
 2.  Fix typo `getZArraryAttributes` -> `getZArrayAttributes`

I can revert (2) if you want to preserve public API