### PR TITLE
Store dimension separator in .zarray

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
@@ -176,6 +176,7 @@ public class ZArrayAttributes {
 		map.put(fillValueKey, fill_value);
 		map.put(orderKey, order);
 		map.put(filtersKey, filters);
+		map.put(dimensionSeparatorKey, dimensionSeparator);
 
 		return map;
 	}


### PR DESCRIPTION
Currently, the dimension separator is not stored in `.zarray` because it is not added in `ZArrayAttributes.asMap()`. This PR adds the dimension separator to the map.

### Open Questions:
 1. Should we only add the dimension separator to the map if it is not the default (`.`)?