### PR TITLE
fix: don't enforce `serializeNulls`, but DO still ensure `null` is still

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
@@ -34,6 +34,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.RawCompression;
 
@@ -222,7 +224,7 @@ public class ZArrayAttributes {
 
 	public static JsonAdapter jsonAdapter = new JsonAdapter();
 
-	public static class JsonAdapter implements JsonDeserializer<ZArrayAttributes> {
+	public static class JsonAdapter implements JsonDeserializer<ZArrayAttributes>, JsonSerializer<ZArrayAttributes> {
 
 		@Override
 		public ZArrayAttributes deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
@@ -249,5 +251,23 @@ public class ZArrayAttributes {
 			}
 		}
 
+		@Override
+		public JsonElement serialize(ZArrayAttributes src, Type typeOfSrc, JsonSerializationContext context) {
+
+			final JsonObject jsonObject = new JsonObject();
+
+			jsonObject.addProperty("zarr_format", src.getZarrFormat());
+			jsonObject.add("shape", context.serialize(src.getShape()));
+			jsonObject.add("chunks", context.serialize(src.getChunks()));
+
+			jsonObject.add("dtype", context.serialize(src.getDType().toString()));
+			jsonObject.add("compressor", context.serialize(src.getCompressor()));
+			jsonObject.addProperty("fill_value", src.getFillValue());
+			jsonObject.addProperty("order", src.getOrder());
+			jsonObject.addProperty("dimension_separator", src.getDimensionSeparator());
+			jsonObject.add("filters", context.serialize(src.getFilters()));
+
+			return jsonObject;
+		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrCompressor.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrCompressor.java
@@ -28,6 +28,7 @@
  */
 package org.janelia.saalfeldlab.n5.zarr;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -35,8 +36,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.gson.JsonNull;
-import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import org.janelia.saalfeldlab.n5.Bzip2Compression;
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.GzipCompression;
@@ -297,5 +299,18 @@ public interface ZarrCompressor {
 		}
 	}
 
-	JsonSerializer<Raw> rawNullAdapter = (src, typeOfSrc, context) -> JsonNull.INSTANCE;
+	TypeAdapter<Raw> rawNullAdapter = new TypeAdapter<Raw>() {
+
+		@Override public void write(JsonWriter out, Raw value) throws IOException {
+			final boolean serializeNull = out.getSerializeNulls();
+			out.setSerializeNulls(true);
+			out.nullValue();
+			out.setSerializeNulls(serializeNull);
+		}
+
+		@Override public Raw read(JsonReader in) {
+
+			return new Raw();
+		}
+	};
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
@@ -863,7 +863,6 @@ public class ZarrKeyValueReader implements CachedGsonKeyValueN5Reader, N5JsonCac
 		gsonBuilder.registerTypeAdapter(ZArrayAttributes.class, ZArrayAttributes.jsonAdapter);
 		gsonBuilder.registerTypeHierarchyAdapter(Filter.class, Filter.jsonAdapter);
 		gsonBuilder.disableHtmlEscaping();
-		gsonBuilder.serializeNulls();
 
 		return gsonBuilder;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
@@ -525,7 +525,7 @@ public class ZarrKeyValueReader implements CachedGsonKeyValueN5Reader, N5JsonCac
 		attrs.addProperty(DatasetAttributes.DATA_TYPE_KEY, zattrs.getDType().getDataType().toString());
 
 		final JsonElement e = attrs.get(ZArrayAttributes.compressorKey);
-		if (e == JsonNull.INSTANCE) {
+		if (e == JsonNull.INSTANCE || e == null) {
 			attrs.add(DatasetAttributes.COMPRESSION_KEY, gson.toJsonTree(new RawCompression()));
 		} else {
 			attrs.add(DatasetAttributes.COMPRESSION_KEY, gson.toJsonTree(

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
@@ -442,7 +442,7 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 		if (attributes == null)
 			return;
 
-		writeJsonResource(normalGroupPath, ZARRAY_FILE, attributes);
+		writeJsonResource(normalGroupPath, ZARRAY_FILE, gson.fromJson(attributes, ZArrayAttributes.class));
 		if (cacheMeta())
 			cache.updateCacheInfo(normalGroupPath, ZARRAY_FILE, attributes);
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -831,8 +831,7 @@ public class N5ZarrTest extends AbstractN5Test {
 			n5.setAttribute(datasetName, DatasetAttributes.COMPRESSION_KEY, rawCompression);
 			n5Compression = n5.getAttribute(datasetName, DatasetAttributes.COMPRESSION_KEY, Compression.class);
 			assertEquals(rawCompression, n5Compression);
-			assertThrows(N5Exception.N5ClassCastException.class, () -> n5.getAttribute(datasetName, ZArrayAttributes.compressorKey, ZarrCompressor.class));
-
+			assertNull(n5.getAttribute(datasetName, ZArrayAttributes.compressorKey, ZarrCompressor.class));
 			final GzipCompression gzipCompression = new GzipCompression();
 			n5.setAttribute(datasetName, DatasetAttributes.COMPRESSION_KEY, gzipCompression);
 			zarrCompression = n5.getAttribute(datasetName, ZArrayAttributes.compressorKey, ZarrCompressor.class);

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -778,7 +778,7 @@ public class N5ZarrTest extends AbstractN5Test {
 	public void testAttributeMapping()  {
 
 		// attribute mapping on by default
-		try (final N5Writer n5 = createTempN5Writer()) {
+		try (final N5Writer n5 = createTempN5Writer(tempN5Location(), new GsonBuilder().serializeNulls())) {
 
 			n5.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, getCompressions()[0]);
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -146,7 +146,7 @@ public class N5ZarrTest extends AbstractN5Test {
 			final String dimensionSeparator,
 			final boolean mapN5DatasetAttributes) throws IOException {
 
-		return createTempN5Writer(location, new GsonBuilder(), dimensionSeparator, mapN5DatasetAttributes, false);
+		return createTempN5Writer(location, gsonBuilder, dimensionSeparator, mapN5DatasetAttributes, false);
 	}
 
 	protected N5Writer createTempN5Writer(
@@ -831,7 +831,7 @@ public class N5ZarrTest extends AbstractN5Test {
 			n5.setAttribute(datasetName, DatasetAttributes.COMPRESSION_KEY, rawCompression);
 			n5Compression = n5.getAttribute(datasetName, DatasetAttributes.COMPRESSION_KEY, Compression.class);
 			assertEquals(rawCompression, n5Compression);
-			assertNull(n5.getAttribute(datasetName, ZArrayAttributes.compressorKey, ZarrCompressor.class));
+			assertThrows(N5Exception.N5ClassCastException.class, () -> n5.getAttribute(datasetName, ZArrayAttributes.compressorKey, ZarrCompressor.class));
 			final GzipCompression gzipCompression = new GzipCompression();
 			n5.setAttribute(datasetName, DatasetAttributes.COMPRESSION_KEY, gzipCompression);
 			zarrCompression = n5.getAttribute(datasetName, ZArrayAttributes.compressorKey, ZarrCompressor.class);


### PR DESCRIPTION
serialized regardless of `serializeNulls` for Raw compression