### PR TITLE
refactor: change addNewCacheInfo to align with change to n5 core

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/cache/ZarrJsonCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/cache/ZarrJsonCache.java
@@ -52,6 +52,11 @@ public class ZarrJsonCache extends N5JsonCache {
 		updateCache(normalPathKey, cacheInfo);
 	}
 
+	@Override public N5CacheInfo addNewCacheInfo(String normalPathKey, String normalCacheKey, JsonElement uncachedAttributes) {
+
+		return cacheGroupAndDataset(normalPathKey);
+	}
+
 	@Deprecated
 	public N5CacheInfo forceAddNewCacheInfo(final String normalPathKey, final String normalCacheKey, final JsonElement uncachedAttributes,
 			final boolean isGroup, final boolean isDataset) {


### PR DESCRIPTION
avoid using `exists` in addNewCacheInfo to support more KVA that cannot expect `exists` calls to return meaningfully. 