### PR TITLE
Support n5-api Codecs and DataBlockSerializers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 
 		<json-simple.version>1.1.1</json-simple.version>
 
-		<n5.version>4.0.0-alpha-1</n5.version>
+		<n5.version>4.0.0-alpha-3</n5.version>
 		<n5-blosc.version>2.0.0-alpha-1</n5-blosc.version>
 		<n5-zstandard.version>2.0.0-alpha1</n5-zstandard.version>
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrDatasetAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrDatasetAttributes.java
@@ -30,6 +30,8 @@ package org.janelia.saalfeldlab.n5.zarr;
 
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.codec.RawBytesArrayCodec;
+import org.janelia.saalfeldlab.n5.zarr.codec.ZarrBytesArrayCodec;
 
 
 /**
@@ -51,8 +53,9 @@ public class ZarrDatasetAttributes extends DatasetAttributes {
 			final String fill_value,
 			final String dimensionSeparator ) {
 
-		super(dimensions, blockSize, dType.getDataType(), compression,
-				dType.createDataBlockCodec(blockSize, fill_value, compression));
+		// TODO should we expose ByteOrder as a parameter?
+		super(dimensions, blockSize, dType.getDataType(), 
+				new ZarrBytesArrayCodec(dType, fill_value), compression);
 		this.dType = dType;
 		this.isRowMajor = isRowMajor;
 		this.dimensionSeparator = dimensionSeparator;
@@ -80,6 +83,8 @@ public class ZarrDatasetAttributes extends DatasetAttributes {
 	}
 
 	public String getDimensionSeparator() {
+
 		return dimensionSeparator;
 	}
+
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
@@ -72,7 +72,6 @@ import org.janelia.saalfeldlab.n5.CompressionAdapter;
 import org.janelia.saalfeldlab.n5.DataBlock;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.DefaultBlockReader;
 import org.janelia.saalfeldlab.n5.GsonUtils;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.LockedChannel;
@@ -82,6 +81,7 @@ import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5URI;
 import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.n5.cache.N5JsonCacheableContainer;
+import org.janelia.saalfeldlab.n5.readdata.ReadData;
 import org.janelia.saalfeldlab.n5.zarr.cache.ZarrJsonCache;
 
 /**
@@ -677,35 +677,6 @@ public class ZarrKeyValueReader implements CachedGsonKeyValueN5Reader, N5JsonCac
 			return GsonUtils.readAttributes(lockedChannel.newReader(), gson);
 		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException("Failed to read " + absolutePath, e);
-		}
-	}
-
-	@Override
-	public DataBlock<?> readBlock(
-			final String pathName,
-			final DatasetAttributes datasetAttributes,
-			final long... gridPosition) throws N5Exception {
-
-		final ZarrDatasetAttributes zarrDatasetAttributes;
-		if (datasetAttributes instanceof ZarrDatasetAttributes)
-			zarrDatasetAttributes = (ZarrDatasetAttributes)datasetAttributes;
-		else
-			zarrDatasetAttributes = getDatasetAttributes(pathName);
-
-		final String normalPathName = N5URI.normalizeGroupPath(pathName);
-		final String absolutePath = absoluteDataBlockPath(normalPathName, gridPosition);
-
-		try (final LockedChannel lockedChannel = keyValueAccess.lockForReading(absolutePath)) {
-			return DefaultBlockReader.readBlock(
-					lockedChannel.newInputStream(),
-					zarrDatasetAttributes,
-					gridPosition);
-		} catch (final N5Exception.N5NoSuchKeyException e) {
-			return null;
-		} catch (final Throwable  e) {
-			throw new N5IOException(
-					"Failed to read block " + Arrays.toString(gridPosition) + " from dataset " + pathName,
-					e);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
@@ -76,7 +76,6 @@ import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DataBlock;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.DefaultBlockWriter;
 import org.janelia.saalfeldlab.n5.GsonKeyValueN5Writer;
 import org.janelia.saalfeldlab.n5.GsonUtils;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
@@ -493,51 +492,6 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 	}
 
 	@Override
-	public <T> void writeBlock(
-			final String pathName,
-			final DatasetAttributes datasetAttributes,
-			final DataBlock<T> dataBlock) throws N5Exception {
-
-		final ZarrDatasetAttributes zarrDatasetAttributes;
-		if (datasetAttributes instanceof ZarrDatasetAttributes)
-			zarrDatasetAttributes = (ZarrDatasetAttributes)datasetAttributes;
-		else
-			zarrDatasetAttributes = getDatasetAttributes(pathName); // TODO is
-																	// this
-																	// correct?
-
-		final String normalPath = N5URI.normalizeGroupPath(pathName);
-		final String path = keyValueAccess
-				.compose(
-						uri,
-						normalPath,
-						getZarrDataBlockPath(
-								dataBlock.getGridPosition(),
-								zarrDatasetAttributes.getDimensionSeparator(),
-								zarrDatasetAttributes.isRowMajor()).toString());
-
-		final String[] components = keyValueAccess.components(path);
-		final String parent = keyValueAccess
-				.compose(Arrays.stream(components).limit(components.length - 1).toArray(String[]::new));
-		try {
-			keyValueAccess.createDirectories(parent);
-			try (
-					final LockedChannel lockedChannel = keyValueAccess.lockForWriting(path);
-					final OutputStream out = lockedChannel.newOutputStream()
-			) {
-				DefaultBlockWriter.writeBlock(
-						out,
-						zarrDatasetAttributes,
-						dataBlock);
-			}
-		} catch (final Throwable e) {
-			throw new N5IOException(
-					"Failed to write block " + Arrays.toString(dataBlock.getGridPosition()) + " into dataset " + path,
-					e);
-		}
-	}
-
-	@Override
 	public boolean deleteBlock(
 			final String path,
 			final long... gridPosition) throws N5Exception {
@@ -565,54 +519,6 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 
 		/* an IOException should have occurred if anything had failed midway */
 		return true;
-	}
-
-	public static byte[] padCrop(
-			final byte[] src,
-			final int[] srcBlockSize,
-			final int[] dstBlockSize,
-			final int nBytes,
-			final int nBits,
-			final byte[] fill_value) {
-
-		assert srcBlockSize.length == dstBlockSize.length : "Dimensions do not match.";
-
-		final int n = srcBlockSize.length;
-
-		if (nBytes != 0) {
-			int[] zero = new int[n];
-			int[] srcSize = new int[n];
-			int[] dstSize = new int[n];
-			int[] size = new int[n];
-			Arrays.setAll(srcSize, d -> srcBlockSize[d] * (d == 0 ? nBytes : 1));
-			Arrays.setAll(dstSize, d -> dstBlockSize[d] * (d == 0 ? nBytes : 1));
-			Arrays.setAll(size, d -> Math.min(srcSize[d], dstSize[d]));
-			final byte[] dst = new byte[safeInt(Intervals.numElements(dstSize))];
-			if (!Arrays.equals(dstSize, size)) {
-				fill(dst, fill_value);
-			}
-			SubArrayCopy.copy(src, srcSize, zero, dst, dstSize, zero, size);
-			return dst;
-		} else {
-			/* TODO deal with bit streams */
-			return null;
-		}
-	}
-
-	private static void fill(final byte[] dst, final byte[] fill_value) {
-		byte allZero = 0;
-		for (byte b : fill_value) {
-			allZero |= b;
-		}
-		if (allZero != 0) {
-			if (fill_value.length == 1) {
-				Arrays.fill(dst, fill_value[0]);
-			} else {
-				for (int i = 0; i < dst.length; i++) {
-					dst[i] = fill_value[i % fill_value.length];
-				}
-			}
-		}
 	}
 
 	protected void redirectDatasetAttribute(

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/codec/ZarrBytesArrayCodec.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/codec/ZarrBytesArrayCodec.java
@@ -1,0 +1,49 @@
+package org.janelia.saalfeldlab.n5.zarr.codec;
+
+import java.nio.ByteOrder;
+
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.codec.BytesCodec;
+import org.janelia.saalfeldlab.n5.codec.DataBlockSerializer;
+import org.janelia.saalfeldlab.n5.codec.RawBytesArrayCodec;
+import org.janelia.saalfeldlab.n5.zarr.DType;
+
+/**
+ * An ArrayCodec that serializes bytes directly, but pads the data into a "full
+ * chunk" per the Zarr specification.
+ */
+public class ZarrBytesArrayCodec extends RawBytesArrayCodec {
+
+	private static final long serialVersionUID = 1173539891671563072L;
+
+	private final String fillValue; 
+	private final DType dtype;
+
+	public ZarrBytesArrayCodec(DType dtype, String fillValue) {
+		this.fillValue = fillValue;
+		this.dtype = dtype;
+	}
+
+	@Override
+	public <T> DataBlockSerializer<T> initialize(final DatasetAttributes attributes, final BytesCodec... bytesCodecs) {
+
+		ensureValidByteOrder(attributes.getDataType(), getByteOrder());
+		return ZarrCodecs.createDataBlockCodec(dtype, attributes.getBlockSize(),
+				fillValue, attributes.getCompression());
+	}
+
+	private static void ensureValidByteOrder(final DataType dataType, final ByteOrder byteOrder) {
+
+		switch (dataType) {
+		case INT8:
+		case UINT8:
+		case STRING:
+		case OBJECT:
+			return;
+		}
+
+		if (byteOrder == null)
+			throw new IllegalArgumentException("DataType (" + dataType + ") requires ByteOrder, but was null");
+	}
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -245,20 +245,6 @@ public class N5ZarrTest extends AbstractN5Test {
 		}
 	}
 
-	@Test
-	public void testPadCrop() {
-
-		final byte[] src = new byte[]{1, 2, 3, 4}; // 2x2
-		final int[] srcBlockSize = new int[]{2, 2};
-		final int[] dstBlockSize = new int[]{3, 3};
-		final int nBytes = 1;
-		final int nBits = 0;
-		final byte[] fillValue = new byte[]{5};
-
-		final byte[] dst = N5ZarrWriter.padCrop(src, srcBlockSize, dstBlockSize, nBytes, nBits, fillValue);
-		assertArrayEquals(new byte[]{1, 2, 5, 3, 4, 5, 5, 5, 5}, dst);
-	}
-
 	@Override
 	@Test
 	public void testVersion() throws NumberFormatException, IOException, URISyntaxException {

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/codec/PadTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/codec/PadTest.java
@@ -1,0 +1,23 @@
+package org.janelia.saalfeldlab.n5.zarr.codec;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class PadTest {
+
+	@Test
+	public void testPadCrop() {
+
+		final byte[] src = new byte[]{1, 2, 3, 4}; // 2x2
+		final int[] srcBlockSize = new int[]{2, 2};
+		final int[] dstBlockSize = new int[]{3, 3};
+		final int nBytes = 1;
+		final int nBits = 0;
+		final byte[] fillValue = new byte[]{5};
+
+		final byte[] dst = ZarrCodecs.padCrop(src, srcBlockSize, dstBlockSize, nBytes, nBits, fillValue);
+		assertArrayEquals(new byte[]{1, 2, 5, 3, 4, 5, 5, 5, 5}, dst);
+	}
+
+}


### PR DESCRIPTION
toward using n5-4.0.0-alpha-3

The main change is that I moved where the logic for padding zarr "chunks" is. It now lives in `ZarrCodecs`  which provide's zarr's default `DataBlockSerializer` . Needed to make `ZarrBytesArrayCodec` create one in its initialize method.

A nice benefit of this change is that the Zarr `N5Reader` and `N5Writer` no longer need to override `readBlock` and `writeBlock` because the differences are all taken care of by the `DataBlockSerializer`.