### PR TITLE
Cache converted DatasetAttributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 
 		<json-simple.version>1.1.1</json-simple.version>
 
-		<n5.version>4.0.0-alpha-4</n5.version>
+		<n5.version>4.0.0-alpha-7-SNAPSHOT</n5.version>
 		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
 		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
 	</properties>

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.RawCompression;
 import org.janelia.saalfeldlab.n5.zarr.ZarrCompressor.Raw;
@@ -137,27 +136,6 @@ public class ZArrayAttributes {
 
 		// empty dimensionSeparator so that the reader's separator is used
 		this(zarr_format, shape, chunks, dtype, compressor, fill_value, order, "", filters);
-	}
-
-	public ZarrDatasetAttributes getDatasetAttributes() {
-
-		final boolean isRowMajor = order == 'C';
-		final long[] dimensions = shape.clone();
-		final int[] blockSize = chunks.clone();
-
-		if (isRowMajor) {
-			ArrayUtils.reverse(dimensions);
-			ArrayUtils.reverse(blockSize);
-		}
-
-		return new ZarrDatasetAttributes(
-				dimensions,
-				blockSize,
-				dtype,
-				compressor.getCompression(),
-				isRowMajor,
-				(fillValue == null || fillValue.isJsonNull()) ? null : fillValue.getAsString(),
-				dimensionSeparator);
 	}
 
 	private static JsonElement parseFillValue(String fillValue, DataType dtype) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
@@ -383,7 +383,7 @@ public class ZarrKeyValueReader implements CachedGsonKeyValueN5Reader, N5JsonCac
 	public DatasetAttributes createDatasetAttributes(final JsonElement attributes) {
 
 		final ZArrayAttributes zarray = getZArrayAttributes(attributes);
-		return zarray != null ? zarray.getDatasetAttributes() : null;
+		return zarray != null ? new ZarrDatasetAttributes(zarray) : null;
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
@@ -28,11 +28,11 @@ package org.janelia.saalfeldlab.n5.zarr;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.janelia.saalfeldlab.n5.CachedGsonKeyValueN5Writer;
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DataBlock;
@@ -65,8 +65,10 @@ import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 import org.janelia.saalfeldlab.n5.serialization.JsonArrayUtils;
 
+import static org.janelia.saalfeldlab.n5.zarr.ZarrDatasetAttributes.createZArrayAttributes;
+
 /**
- * Zarr {@link KeyValueWriter} implementation.
+ * Zarr {@link KeyValueAccess} implementation.
  *
  * @author Stephan Saalfeld
  * @author John Bogovic
@@ -239,16 +241,37 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 		}
 	}
 
+	private HashMap<DatasetAttributes, ZarrDatasetAttributes> datasetAttributesMap = new HashMap<>();
+
+
+	private ZarrDatasetAttributes getConvertedDatasetAttributes(final DatasetAttributes datasetAttributes) {
+
+		final ZarrDatasetAttributes zarrAttrs;
+		if (datasetAttributes instanceof ZarrDatasetAttributes)
+			zarrAttrs = ((ZarrDatasetAttributes)datasetAttributes);
+		else if (datasetAttributesMap.containsKey(datasetAttributes)) {
+			zarrAttrs = datasetAttributesMap.get(datasetAttributes);
+			datasetAttributesMap.put(datasetAttributes, zarrAttrs);
+		}
+		else {
+			final ZArrayAttributes zArrayAttrs = createZArrayAttributes(dimensionSeparator, datasetAttributes);
+			zarrAttrs = new ZarrDatasetAttributes(zArrayAttrs);
+			datasetAttributesMap.put(datasetAttributes, zarrAttrs);
+		}
+		return zarrAttrs;
+	}
+
 	@Override
-	public void createDataset(
+	public ZarrDatasetAttributes createDataset(
 			final String path,
 			final DatasetAttributes datasetAttributes) throws N5Exception {
 
 		final String normalPath = N5URI.normalizeGroupPath(path);
 		boolean wasGroup = false;
 		if (cacheMeta()) {
-			if (getCache().isDataset(normalPath, ZARRAY_FILE))
-				return;
+			if (getCache().isDataset(normalPath, ZARRAY_FILE)) {
+				return getConvertedDatasetAttributes(datasetAttributes);
+			}
 			else if (getCache().isGroup(normalPath, ZGROUP_FILE)) {
 				wasGroup = true;
 				// TODO tests currently require that we can make a dataset on a group
@@ -273,7 +296,8 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 
 		// These three lines are preferable to setDatasetAttributes because they
 		// are more efficient wrt caching
-		final ZArrayAttributes zarray = createZArrayAttributes(datasetAttributes);
+		final ZarrDatasetAttributes zarrDatasetAttributes = getConvertedDatasetAttributes(datasetAttributes);
+		final ZArrayAttributes zarray = zarrDatasetAttributes.getZArrayAttributes();
 		final JsonElement attributes = gson.toJsonTree(zarray);
 		writeJson(normalPath, ZARRAY_FILE, attributes);
 
@@ -290,6 +314,7 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 
 			getCache().addChildIfPresent(parent, pathParts[pathParts.length - 1]);
 		}
+		return zarrDatasetAttributes;
 	}
 
 	@Override
@@ -377,29 +402,9 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 			final String pathName,
 			final DatasetAttributes datasetAttributes) throws N5Exception {
 
-		setZArrayAttributes(pathName, createZArrayAttributes(datasetAttributes));
-	}
-
-	protected ZArrayAttributes createZArrayAttributes(final DatasetAttributes datasetAttributes) {
-
-		final long[] shape = datasetAttributes.getDimensions().clone();
-		ArrayUtils.reverse(shape);
-		final int[] chunks = datasetAttributes.getBlockSize().clone();
-		ArrayUtils.reverse(chunks);
-		final DType dType = new DType(datasetAttributes.getDataType());
-
-		final ZArrayAttributes zArrayAttributes = new ZArrayAttributes(
-				N5ZarrReader.VERSION.getMajor(),
-				shape,
-				chunks,
-				dType,
-				ZarrCompressor.fromCompression(datasetAttributes.getCompression()),
-				"0",
-				'C',
-				dimensionSeparator,
-				dType.getFilters());
-
-		return zArrayAttributes;
+		final ZarrDatasetAttributes zarrDatasetAttributes = getConvertedDatasetAttributes(datasetAttributes);
+		final ZArrayAttributes zArray = zarrDatasetAttributes.getZArrayAttributes();
+		setZArrayAttributes(pathName, zArray);
 	}
 
 	/**
@@ -508,11 +513,8 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 					final DatasetAttributes datasetAttributes,
 					final DataBlock<T>... dataBlocks) {
 
-		// If already ZarrDatasetAttributes, use it directly to preserve fill value and other Zarr-specific properties
-		final DatasetAttributes zarrDsetAttrs = (datasetAttributes instanceof ZarrDatasetAttributes)
-				? datasetAttributes
-				: createZArrayAttributes(datasetAttributes).getDatasetAttributes();
-		CachedGsonKeyValueN5Writer.super.writeBlocks( datasetPath, zarrDsetAttrs, dataBlocks);
+		final ZarrDatasetAttributes zarrDatasetAttributes = getConvertedDatasetAttributes(datasetAttributes);
+		CachedGsonKeyValueN5Writer.super.writeBlocks( datasetPath, zarrDatasetAttributes, dataBlocks);
 	}
 
 	@Override
@@ -521,11 +523,8 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 			final DatasetAttributes datasetAttributes,
 			final DataBlock<T> dataBlock) {
 
-		// If already ZarrDatasetAttributes, use it directly to preserve fill value and other Zarr-specific properties
-		final DatasetAttributes zarrDsetAttrs = (datasetAttributes instanceof ZarrDatasetAttributes)
-				? datasetAttributes
-				: createZArrayAttributes(datasetAttributes).getDatasetAttributes();
-		CachedGsonKeyValueN5Writer.super.writeBlock( path, zarrDsetAttrs, dataBlock);
+		final ZarrDatasetAttributes zarrDatasetAttributes = getConvertedDatasetAttributes(datasetAttributes);
+		CachedGsonKeyValueN5Writer.super.writeBlock( path, zarrDatasetAttributes, dataBlock);
 	}
 
 	public static byte[] padCrop(
@@ -758,7 +757,6 @@ public class ZarrKeyValueWriter extends ZarrKeyValueReader implements CachedGson
 
 			return zgroup;
 		}
-
 	}
 
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -269,10 +269,23 @@ public class N5ZarrTest extends AbstractN5Test {
 	public void testBlocksPaddedWithFillValue() {
 
 		final String dsetPath = "";
-		final long[] dimensions = new long[]{4, 3};
-		final int[] blockSize = new int[]{3, 3};
+		final long[] shape = new long[]{3, 4};
+		final int[] chunkSize = new int[]{3, 3};
 		final String fillValue = "111";
 		final DType dtype = new DType(DataType.INT8);
+
+		final ZArrayAttributes zarray = new ZArrayAttributes(
+				2,
+				shape,
+				chunkSize,
+				dtype,
+				ZarrCompressor.fromCompression(new RawCompression()),
+				fillValue,
+				'F',
+				".",
+				dtype.getFilters());
+
+		ZarrDatasetAttributes attributes = new ZarrDatasetAttributes(zarray);
 
 		final long[] pos = new long[]{1, 0};
 		final byte[] data = new byte[]{1, 2, 3};
@@ -284,7 +297,6 @@ public class N5ZarrTest extends AbstractN5Test {
 		int[] croppedBlockSize = {1, 3};
 		DataBlock<byte[]> blk10 = new ByteArrayDataBlock(croppedBlockSize, pos, data);
 
-		ZarrDatasetAttributes attributes = new ZarrDatasetAttributes(dimensions, blockSize, dtype, new RawCompression(), false, fillValue);
 		try (final N5Writer n5 = createTempN5Writer()) {
 
 			n5.createDataset(dsetPath, attributes);


### PR DESCRIPTION
When N5Writer methods are called with generic DatasetAttributes, N5Zarr must convert to ZarrDatasetAttributes prior to writing blocks and creating datasets. This PR caches the conversion for reuse, so the conversion isn't necessary each time. 