### PR TITLE
Retain License at a single file at the root of the project

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+## BSD 2-Clause License
+
+Copyright (c) 2019-2026, Stephan Saalfeld
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/doc/LICENSE.md
+++ b/doc/LICENSE.md
@@ -1,0 +1,26 @@
+## BSD 2-Clause License
+
+Copyright (c) @project.inceptionYear@-@current.year@, Stephan Saalfeld
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>43.0.0</version>
+		<version>44.0.0</version>
 		<relativePath />
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5-zarr</artifactId>
-	<version>2.0.0-alpha-9-SNAPSHOT</version>
+	<version>2.0.0</version>
 
 	<name>N5 Zarr</name>
 	<description>Zarr filesystem backend for N5</description>
@@ -138,10 +138,10 @@
 
 		<json-simple.version>1.1.1</json-simple.version>
 
-		<n5.version>4.0.0-alpha-12</n5.version>
-		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
-		<n5-imglib2.version>7.1.0-alpha-8</n5-imglib2.version>
-		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
+		<n5.version>4.0.0</n5.version>
+		<n5-blosc.version>2.0.0</n5-blosc.version>
+		<n5-imglib2.version>8.0.0</n5-imglib2.version>
+		<n5-zstandard.version>2.0.0</n5-zstandard.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,9 @@
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
 
+		<scijava.jvm.version>8</scijava.jvm.version>
+		<scijava.jvm.build.version>[1.8.0-101,)</scijava.jvm.build.version>
+
 		<doclint>none</doclint>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,9 @@
 		<license.projectName>Not HDF5</license.projectName>
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
+		<!-- managed by `copy-resources` plugin  -->
+		<license.skipUpdateLicense>true</license.skipUpdateLicense>
+		<license.skipUpdateProjectLicense>true</license.skipUpdateProjectLicense>
 
 		<scijava.jvm.version>8</scijava.jvm.version>
 		<scijava.jvm.build.version>[1.8.0-101,)</scijava.jvm.build.version>
@@ -165,10 +168,10 @@
 			<artifactId>n5-zstandard</artifactId>
 		</dependency>
 		<dependency>
-  	  <groupId>commons-codec</groupId>
-  	  <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 		</dependency>
@@ -209,6 +212,23 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>timestamp-property</id>
+							<goals>
+								<goal>timestamp-property</goal>
+							</goals>
+							<phase>validate</phase>
+							<configuration>
+								<name>current.year</name>
+								<pattern>yyyy</pattern>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
 				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>
 					<executions>

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/DType.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/DType.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2022 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import java.nio.ByteBuffer;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/Filter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/Filter.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import com.google.gson.JsonDeserializationContext;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrReader.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrWriter.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZArrayAttributes.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import java.lang.reflect.Type;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrCompressor.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrCompressor.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import java.io.IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrDatasetAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrDatasetAttributes.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2022 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import com.google.gson.Gson;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueReader.java
@@ -1,28 +1,3 @@
-/**
- * Copyright (c) 2017--2021, Stephan Saalfeld
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import java.io.IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/ZarrKeyValueWriter.java
@@ -1,28 +1,3 @@
-/**
- * Copyright (c) 2017--2021, Stephan Saalfeld
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import java.io.IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/cache/ZarrJsonCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/cache/ZarrJsonCache.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr.cache;
 
 import org.janelia.saalfeldlab.n5.cache.N5JsonCache;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/package-info.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/package-info.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 
 /**
  * Zarr backends for N5

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3Compressor.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3Compressor.java
@@ -217,9 +217,6 @@ public static ZarrV3Compressor fromCompression(final DataCodecInfo dataCodec) {
 			case BloscCompression.BITSHUFFLE:
 				shuffle = "bitshuffle";
 				break;
-			case BloscCompression.AUTOSHUFFLE:
-				shuffle = typesize == 1 ? "bitshuffle" : "shuffle";
-				break;
 			default:
 				throw new N5Exception("Invalid shuffle: " + _shuffle);
 			}

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3Compressor.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3Compressor.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2022 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr.v3;
 
 import java.lang.reflect.Field;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributes.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2022 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr.v3;
 
 import java.lang.reflect.Type;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributes.java
@@ -607,6 +607,11 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		return new Builder(dimensions, dataType);
 	}
 
+	public static Builder builder(DatasetAttributes attributes) {
+
+		return new Builder(attributes);
+	}
+
 	/**
 	 * Builder for constructing {@link ZarrV3DatasetAttributes} instances.
 	 * <p>
@@ -641,7 +646,7 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		private DataCodecInfo[] shardIndexDataCodecInfos = new DataCodecInfo[0];
 
 		// For sharding
-		private int[] shardSize;
+		private int[] chunkSize;
 
 		/**
 		 * Creates a new builder with the required parameters.
@@ -655,7 +660,7 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 			super(dimensions, dataType);
 			this.dimensions = dimensions.clone();
 			this.dataType = ZarrV3DataType.fromDataType(dataType);
-			this.blockSize = Arrays.stream(dimensions).mapToInt(x -> (int)x).toArray();
+			this.blockSize = defaultChunkShape(dimensions);
 		}
 
 		/**
@@ -669,7 +674,21 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 			super(dimensions, dataType.getDataType());
 			this.dimensions = dimensions.clone();
 			this.dataType = dataType;
-			this.blockSize = Arrays.stream(dimensions).mapToInt(x -> (int)x).toArray();
+			this.blockSize = defaultChunkShape(dimensions);
+		}
+
+		public Builder(final DatasetAttributes attributes) {
+
+			super( attributes.getDimensions(), attributes.getDataType());
+			this.dimensions = attributes.getDimensions();
+			this.dataType = ZarrV3DataType.fromDataType(attributes.getDataType());
+			dataCodecInfos(attributes.getDataCodecInfos());
+			if (attributes.isSharded()) {
+				chunkSize(attributes.getChunkSize());
+				blockSize(attributes.getBlockSize());
+			} else {
+				blockSize(attributes.getBlockSize());
+			}
 		}
 
 		/**
@@ -685,16 +704,37 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		}
 
 		/**
-		 * Sets the shard shape for sharded arrays.
+		 * Sets the chunk shape for sharded arrays.
 		 * When set, chunks will be grouped into shards of this size.
 		 *
-		 * @param shardSize the shard dimensions
+		 * @param chunkSize the shard dimensions
 		 * @return this builder
 		 */
-		public Builder shardSize(final int[] shardSize) {
+		public Builder chunkSize(final int[] chunkSize) {
 
-			this.shardSize = shardSize.clone();
+			validateLength("chunk size", chunkSize.length);
+			validateBlockChunkSize(blockSize, chunkSize);
+
+			this.chunkSize = chunkSize.clone();
 			return this;
+		}
+		
+		private void validateBlockChunkSize( int[] blockSize, int[] chunkSize ) {
+
+			if (blockSize != null && chunkSize != null) {
+				for (int i = 0; i < chunkSize.length; i++) {
+					if (chunkSize[i] > blockSize[i])
+						throw new IllegalArgumentException(
+								String.format("index %d: chunk size (%d) is greater than block size (%d)",
+										i, chunkSize[i], blockSize[i]));
+				}
+			}
+		}
+
+		private void validateLength(final String name, final int length) {
+			if (length != dimensions.length)
+				throw new IllegalArgumentException(name + " must be same length as dimensions (" +
+						+dimensions.length + ") but is (" + length + ")");
 		}
 
 		/**
@@ -754,7 +794,7 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		public Builder compression(final Compression compression) {
 
 			if (compression != null && !(compression instanceof RawCompression)) {
-				this.dataCodecInfos = new DataCodecInfo[]{ZarrV3Compressor.fromCompression(compression)};
+				this.dataCodecInfos = new DataCodecInfo[]{compression};
 			}
 			return this;
 		}
@@ -824,21 +864,23 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 					? chunkKeyEncoding
 					: new DefaultChunkKeyEncoding(dimensionSeparator);
 
-			final int[] resolvedBlockSize = blockSize != null
-					? blockSize
-					: defaultChunkShape(dimensions);
 
 			// Determine if sharding is enabled
-			if (shardSize != null) {
+			if (blockSize != null && chunkSize != null) {
+				// if both blockSize and chunkSize are specified, the dataset is sharded
+				final int[] resolvedChunkSize = chunkSize != null
+						? chunkSize
+						: defaultChunkShape(dimensions);
+
 				// Sharded configuration
 				final BlockCodecInfo resolvedBlockCodecInfo = blockCodecInfo != null
 						? blockCodecInfo
-						: defaultShardCodecInfo(resolvedBlockSize, dataCodecInfos, shardIndexDataCodecInfos);
+						: defaultShardCodecInfo(resolvedChunkSize, dataCodecInfos, shardIndexDataCodecInfos);
 
 				// For sharding, the outer chunk is the shard size
 				return new ZarrV3DatasetAttributes(
 						dimensions,
-						shardSize,
+						blockSize,
 						dataType,
 						fillValue,
 						resolvedDimensionNames,
@@ -846,6 +888,17 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 						resolvedBlockCodecInfo,
 						datasetCodecInfos);
 			} else {
+				// one or both of blockSize or chunkSize is null.
+				// either one sets the block size
+				final int[] resolvedBlockSize; 
+				if( chunkSize != null )
+					resolvedBlockSize = chunkSize;
+				else if( blockSize != null )
+					
+					resolvedBlockSize = blockSize;
+				else
+					resolvedBlockSize = defaultChunkShape(dimensions);
+
 				// Non-sharded configuration
 				final BlockCodecInfo resolvedBlockCodecInfo = blockCodecInfo != null
 						? blockCodecInfo

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributes.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributes.java
@@ -623,7 +623,7 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 	 *     .build();
 	 * }</pre>
 	 */
-	public static class Builder {
+	public static class Builder extends DatasetAttributes.Builder {
 
 		// Required parameters
 		private final long[] dimensions;
@@ -651,6 +651,8 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		 */
 		public Builder(final long[] dimensions, final DataType dataType) {
 
+
+			super(dimensions, dataType);
 			this.dimensions = dimensions.clone();
 			this.dataType = ZarrV3DataType.fromDataType(dataType);
 			this.blockSize = Arrays.stream(dimensions).mapToInt(x -> (int)x).toArray();
@@ -664,6 +666,7 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		 */
 		public Builder(final long[] dimensions, final ZarrV3DataType dataType) {
 
+			super(dimensions, dataType.getDataType());
 			this.dimensions = dimensions.clone();
 			this.dataType = dataType;
 			this.blockSize = Arrays.stream(dimensions).mapToInt(x -> (int)x).toArray();
@@ -685,7 +688,7 @@ public class ZarrV3DatasetAttributes extends DatasetAttributes implements ZarrV3
 		 * Sets the shard shape for sharded arrays.
 		 * When set, chunks will be grouped into shards of this size.
 		 *
-		 * @param shardShape the shard dimensions
+		 * @param shardSize the shard dimensions
 		 * @return this builder
 		 */
 		public Builder shardSize(final int[] shardSize) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3KeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3KeyValueReader.java
@@ -1,28 +1,3 @@
-/**
- * Copyright (c) 2017--2021, Stephan Saalfeld
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 package org.janelia.saalfeldlab.n5.zarr.v3;
 
 import java.lang.reflect.Type;

--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3KeyValueWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3KeyValueWriter.java
@@ -1,28 +1,3 @@
-/**
- * Copyright (c) 2017--2021, Stephan Saalfeld
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 package org.janelia.saalfeldlab.n5.zarr.v3;
 
 import java.util.Collections;

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/N5ZarrTest.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/ZarrCachedFSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/ZarrCachedFSTest.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2025 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributesTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3DatasetAttributesTest.java
@@ -1,0 +1,103 @@
+package org.janelia.saalfeldlab.n5.zarr.v3;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.RawCompression;
+import org.janelia.saalfeldlab.n5.zarr.chunks.DefaultChunkKeyEncoding;
+import org.junit.Test;
+
+public class ZarrV3DatasetAttributesTest {
+
+	@Test
+	public void builderTests() {
+
+		final long[] dims = new long[]{100, 200, 300};
+		final int[] blk = new int[]{32, 32, 32};
+
+		// default blockSize uses defaultChunkShape, not full dimensions
+		final ZarrV3DatasetAttributes defaultBlk = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32).build();
+		assertArrayEquals(ZarrV3DatasetAttributes.defaultChunkShape(dims), defaultBlk.getBlockSize());
+
+		// blockSize is reflected in output
+		final ZarrV3DatasetAttributes withBlk = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).build();
+		assertArrayEquals(blk, withBlk.getBlockSize());
+		assertFalse(withBlk.isSharded());
+
+		// fillValue is reflected
+		final ZarrV3DatasetAttributes withFill = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).fillValue("1.5").build();
+		assertEquals("1.5", withFill.getFillValue());
+
+		// dimensionNames are reflected
+		final String[] names = new String[]{"x", "y", "z"};
+		final ZarrV3DatasetAttributes withNames = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).dimensionNames(names).build();
+		assertArrayEquals(names, withNames.getDimensionNames());
+
+		// dimensionSeparator is reflected in chunk key encoding
+		final ZarrV3DatasetAttributes withSlash = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).dimensionSeparator("/").build();
+		assertTrue(withSlash.relativeBlockPath(1, 2, 3).contains("/"));
+
+		final ZarrV3DatasetAttributes withDot = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).dimensionSeparator(".").build();
+		assertTrue(withDot.relativeBlockPath(1, 2, 3).contains("."));
+
+		// chunkKeyEncoding overrides dimensionSeparator
+		final DefaultChunkKeyEncoding encoding = new DefaultChunkKeyEncoding(".");
+		final ZarrV3DatasetAttributes withEncoding = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).chunkKeyEncoding(encoding).build();
+		assertTrue(withEncoding.relativeBlockPath(1, 2, 3).contains("."));
+
+		// compression sets a data codec; RawCompression is a no-op
+		final ZarrV3DatasetAttributes withGzip = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).compression(new GzipCompression()).build();
+		assertEquals(1, withGzip.getDataCodecInfos().length);
+
+		final ZarrV3DatasetAttributes withRaw = ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+				.blockSize(blk).compression(new RawCompression()).build();
+		assertEquals(0, withRaw.getDataCodecInfos().length);
+
+		// sharding: both blockSize (shard) and chunkSize (inner) set
+		final int[] shardSize = new int[]{64, 64, 64};
+		final int[] chunkSize = new int[]{16, 16, 16};
+		final ZarrV3DatasetAttributes sharded = ZarrV3DatasetAttributes.builder(dims, DataType.UINT16)
+				.blockSize(shardSize).chunkSize(chunkSize).build();
+		assertTrue(sharded.isSharded());
+		assertArrayEquals(shardSize, sharded.getBlockSize());
+		assertArrayEquals(chunkSize, sharded.getChunkSize());
+		assertNotNull(sharded.getBlockCodecInfo());
+
+		// round-trip through Builder(DatasetAttributes)
+		final ZarrV3DatasetAttributes roundTrip = ZarrV3DatasetAttributes.builder(withGzip).build();
+		assertArrayEquals(withGzip.getDimensions(), roundTrip.getDimensions());
+		assertArrayEquals(withGzip.getBlockSize(), roundTrip.getBlockSize());
+		assertEquals(withGzip.getDataType(), roundTrip.getDataType());
+		assertEquals(withGzip.getDataCodecInfos().length, roundTrip.getDataCodecInfos().length);
+
+		// validateLength: blockSize wrong length throws
+		try {
+			ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32).blockSize(new int[]{32, 32}).build();
+			// blockSize setter does not validate length — only chunkSize() does, so no exception expected here
+		} catch (final IllegalArgumentException e) {
+			// acceptable if validation is added to blockSize()
+		}
+
+		// validateBlockChunkSize: chunkSize > blockSize throws
+		try {
+			ZarrV3DatasetAttributes.builder(dims, DataType.FLOAT32)
+					.blockSize(new int[]{16, 16, 16})
+					.chunkSize(new int[]{32, 32, 32})
+					.build();
+			throw new AssertionError("Expected IllegalArgumentException for chunkSize > blockSize");
+		} catch (final IllegalArgumentException expected) {}
+	}
+
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/v3/ZarrV3Test.java
@@ -1,31 +1,3 @@
-/*-
- * #%L
- * Not HDF5
- * %%
- * Copyright (C) 2019 - 2022 Stephan Saalfeld
- * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- * #L%
- */
 package org.janelia.saalfeldlab.n5.zarr.v3;
 
 import static org.junit.Assert.assertArrayEquals;


### PR DESCRIPTION
See https://github.com/saalfeldlab/n5/issues/188 for motivation:

- Removes redundant license headers from source files
- Disable the auto-adding of license headers to source files
- Retain project license in a single `LICENSE.md` file at the root based on `doc/LICENSE.md` template
- specify `license.skipUpdateProjectLicense = true` in `pom.xml
  - Avoids errantly generating a duplicate `LICENSE.txt`
  - used by `scijava-script/release-version.sh` script to disable license updates without requiring `--skip-license-update` 