### PR TITLE
fix: V2ChunkKeyEncoding must not prepend the separator

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/zarr/chunks/V2ChunkKeyEncoding.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/zarr/chunks/V2ChunkKeyEncoding.java
@@ -20,6 +20,8 @@ public class V2ChunkKeyEncoding implements ChunkKeyEncoding {
 	public static String DEFAULT_SEPARATOR = ".";
 
 	public V2ChunkKeyEncoding(final String separator) {
+
+		assert (VALID_SEPARATORS.contains(separator));
 		this.separator = separator;
 	}
 
@@ -36,8 +38,10 @@ public class V2ChunkKeyEncoding implements ChunkKeyEncoding {
 	@Override
 	public String getChunkPath(final long[] gridPosition) {
 
+		// the v2 encoding has no prefix and no leading separator, i.e. the key
+		// for chunk (1, 2, 3) is "1.2.3" - see
+		// https://zarr-specs.readthedocs.io/en/latest/v3/chunk-key-encodings/v2/index.html
 		final StringBuilder pathStringBuilder = new StringBuilder();
-		pathStringBuilder.append(getSeparator());
 		pathStringBuilder.append(gridPosition[gridPosition.length - 1]);
 		for (int i = gridPosition.length - 2; i >= 0; --i) {
 			pathStringBuilder.append(getSeparator());
@@ -47,4 +51,8 @@ public class V2ChunkKeyEncoding implements ChunkKeyEncoding {
 		return pathStringBuilder.toString();
 	}
 
+	@Override public String toString() {
+
+		return String.format("%s[separator=%s]", getClass().getSimpleName(), getSeparator());
+	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/zarr/chunks/ChunkKeyEncodingTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/zarr/chunks/ChunkKeyEncodingTest.java
@@ -1,0 +1,133 @@
+package org.janelia.saalfeldlab.n5.zarr.chunks;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.janelia.saalfeldlab.n5.ByteArrayDataBlock;
+import org.janelia.saalfeldlab.n5.DataBlock;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3DataType;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3DatasetAttributes;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
+import org.junit.Test;
+
+import com.google.gson.GsonBuilder;
+
+/**
+ * Tests for chunk key encodings, see
+ * https://zarr-specs.readthedocs.io/en/latest/v3/chunk-key-encodings
+ */
+public class ChunkKeyEncodingTest {
+
+	@Test
+	public void testChunkKeys() {
+
+		// the default encoding prefixes with "c", the v2 encoding has no prefix
+		// and, in particular, no leading separator
+		assertEquals("c/1/2/3", new DefaultChunkKeyEncoding("/").getChunkPath(new long[]{3, 2, 1}));
+		assertEquals("c.1.2.3", new DefaultChunkKeyEncoding(".").getChunkPath(new long[]{3, 2, 1}));
+
+		assertEquals("1.2.3", new V2ChunkKeyEncoding(".").getChunkPath(new long[]{3, 2, 1}));
+		assertEquals("1/2/3", new V2ChunkKeyEncoding("/").getChunkPath(new long[]{3, 2, 1}));
+
+		// one dimensional
+		assertEquals("5", new V2ChunkKeyEncoding(".").getChunkPath(new long[]{5}));
+		assertEquals("0.0.0.0", new V2ChunkKeyEncoding(".").getChunkPath(new long[]{0, 0, 0, 0}));
+	}
+
+	/**
+	 * A v2-encoded chunk must be written to, and read from, a key without a
+	 * leading separator, see
+	 * https://github.com/saalfeldlab/n5-zarr/issues/98
+	 */
+	@Test
+	public void testV2ChunkKeyReadWrite() throws IOException {
+
+		final Path root = Files.createTempDirectory("zarr-v3-v2-key-test");
+		final long[] dimensions = new long[]{4, 4};
+		final int[] chunkShape = new int[]{2, 2};
+
+		final ZarrV3DatasetAttributes attributes = new ZarrV3DatasetAttributes(
+				dimensions,
+				new ChunkAttributes(new RegularChunkGrid(chunkShape), new V2ChunkKeyEncoding(".")),
+				ZarrV3DataType.fromDataType(DataType.UINT8),
+				"0",
+				null, // dimension names
+				null, // block codec
+				null); // dataset codecs
+
+		assertEquals("0.0", attributes.relativeBlockPath(0, 0));
+		assertEquals("1.0", attributes.relativeBlockPath(0, 1));
+
+		final byte[] data = new byte[]{1, 2, 3, 4};
+		try (ZarrV3KeyValueWriter zarr = new ZarrV3KeyValueWriter(
+				new FileSystemKeyValueAccess(), root.toString(), new GsonBuilder(), false)) {
+
+			zarr.createDataset("a", attributes);
+			zarr.writeBlock("a", attributes, new ByteArrayDataBlock(chunkShape, new long[]{0, 0}, data));
+		}
+
+		// the chunk must be stored at "a/0.0", not "a/.0.0"
+		assertTrue("chunk written to spec-correct key", Files.exists(root.resolve("a").resolve("0.0")));
+
+		try (ZarrV3KeyValueReader zarr = new ZarrV3KeyValueReader(
+				new FileSystemKeyValueAccess(), root.toString(), new GsonBuilder(), false)) {
+
+			final ZarrV3DatasetAttributes readAttributes = (ZarrV3DatasetAttributes)zarr.getDatasetAttributes("a");
+			assertTrue("v2 chunk key encoding round trips",
+					readAttributes.getChunkAttributes().getKeyEncoding() instanceof V2ChunkKeyEncoding);
+
+			final DataBlock<?> block = zarr.readBlock("a", readAttributes, 0, 0);
+			assertNotNull("block read", block);
+			assertArrayEquals(data, (byte[])block.getData());
+		}
+	}
+
+	/**
+	 * Reads a hand-written container using the v2 chunk key encoding, i.e. one
+	 * that was not written by this library.
+	 */
+	@Test
+	public void testReadV2ChunkKeyContainer() throws IOException {
+
+		final Path root = Files.createTempDirectory("zarr-v3-v2-key-external");
+		write(root.resolve("zarr.json"), "{\"zarr_format\":3,\"node_type\":\"group\",\"attributes\":{}}");
+
+		final Path dataset = Files.createDirectories(root.resolve("a"));
+		write(dataset.resolve("zarr.json"),
+				"{\"zarr_format\":3,\"node_type\":\"array\",\"shape\":[4,4],\"data_type\":\"uint8\","
+						+ "\"chunk_grid\":{\"name\":\"regular\",\"configuration\":{\"chunk_shape\":[2,2]}},"
+						+ "\"chunk_key_encoding\":{\"name\":\"v2\",\"configuration\":{\"separator\":\".\"}},"
+						+ "\"fill_value\":0,\"attributes\":{},"
+						+ "\"codecs\":[{\"name\":\"bytes\",\"configuration\":{\"endian\":\"little\"}}]}");
+
+		final byte[] data = new byte[]{1, 2, 3, 4};
+		Files.write(dataset.resolve("0.0"), data);
+
+		try (ZarrV3KeyValueReader zarr = new ZarrV3KeyValueReader(
+				new FileSystemKeyValueAccess(), root.toString(), new GsonBuilder(), false)) {
+
+			final ZarrV3DatasetAttributes attributes = (ZarrV3DatasetAttributes)zarr.getDatasetAttributes("/a");
+			assertEquals("0.0", attributes.relativeBlockPath(0, 0));
+
+			final DataBlock<?> block = zarr.readBlock("/a", attributes, 0, 0);
+			assertNotNull("block read", block);
+			assertArrayEquals(data, (byte[])block.getData());
+		}
+	}
+
+	private static void write(final Path path, final String contents) throws IOException {
+
+		Files.write(path, contents.getBytes(StandardCharsets.UTF_8));
+	}
+}


### PR DESCRIPTION
Fixes #98.

## Root cause

`V2ChunkKeyEncoding.getChunkPath` was copied from `DefaultChunkKeyEncoding`, which builds `"c" + separator + indices`. When the `"c"` prefix was dropped for the v2 encoding, the separator that followed it was left behind, so every key gained a leading separator:

```java
a.relativeBlockPath(5, 4, 3, 0);   // ".0.3.4.5"  <- leading separator
```

The key composes into `<array>/.0.3.4.5`, which does not exist, so `readBlock` returns `null` for every chunk. With `"/"` as the separator it produces a `//` in the key instead.

This is silent downstream: `zarr.json` does not go through the chunk key encoder, so the array metadata parses perfectly and the dataset opens with the right dimensions, block size, data type and calibration — and then renders uniformly as the fill value. In BigDataViewer that is a completely black image with no error anywhere.

`DefaultChunkKeyEncoding` is unaffected, so this only hits arrays written with `"chunk_key_encoding": {"name": "v2"}`.

Per the [spec](https://zarr-specs.readthedocs.io/en/latest/v3/chunk-key-encodings/v2/index.html), the v2 key for chunk `(1, 2, 3)` is `1.2.3` — no prefix, no leading separator.

## Change

Emit the separator only *between* indices. The index reversal itself was already correct.

Also added the `VALID_SEPARATORS` assert and a `toString()`, for parity with `DefaultChunkKeyEncoding`.

## Tests

New `ChunkKeyEncodingTest` with three tests:

1. exact key strings for both encodings and both separators;
2. a write/read round trip through `ZarrV3KeyValueWriter` using a v2 encoding, asserting the chunk lands at `a/0.0` on disk and reads back;
3. the reproducer from #98 verbatim — a hand-written `zarr.json` plus a chunk at `a/0.0`, read through `ZarrV3KeyValueReader`, i.e. a container this library did not write.

All three fail on the unmodified `V2ChunkKeyEncoding` and pass with the fix. Full suite is green: `Tests run: 237, Failures: 0, Errors: 0, Skipped: 41`.

## Not addressed here

`ZarrV3DatasetAttributes.Builder.chunkKeyEncoding` takes `DefaultChunkKeyEncoding` rather than the `ChunkKeyEncoding` interface, so a v2-encoded array cannot be created through the builder — only via the `ChunkAttributes` constructor, which is what test 2 does. Widening that signature seemed like a separate API decision, so I left it alone; happy to include it if you'd prefer.

Verified against the real-world case from #98: an OME-NGFF 0.5 container served by webKnossos from its `zarr3_experimental` endpoint, which writes `"chunk_key_encoding": {"name": "v2", "configuration": {"separator": "."}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
